### PR TITLE
Remove requirements.txt installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This package takes a ROS1 XML launch file and converts it to a ROS2 Python launc
 ## Installation
 
 ```
-pip3 install -r requirements.txt --user
 pip3 install -e ./ --user
 ```
 


### PR DESCRIPTION
Requirements have been added to setup.py instead of a requirements.txt file. Updating README to match.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
